### PR TITLE
Remove shebang from utils file (fixed Node LTS error)

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 'use strict';
 
 const path = require('path');


### PR DESCRIPTION
When you try to use this library under Node LTS (v12), you get an error when you `require` it.

```
Unhandled rejection /Users/omarestrella/Development/orgspan/ms-teams-integration/node_modules/ember-chromium/utils.js:1
(function (exports, require, module, __filename, __dirname) { #!/usr/bin/env node
                                                              ^

SyntaxError: Invalid or unexpected token
    at new Script (vm.js:88:7)
```