### PR TITLE
Migrate from omaha proxy to chromiumdash

### DIFF
--- a/download-chrome.js
+++ b/download-chrome.js
@@ -98,7 +98,7 @@ module.exports = (function () {
     console.log('Chrome is already installed');
   } else {
     console.log('Chrome is not installed, triggering download');
-    return utils.getChromiumBranchingPoint(versionNumber)
+    return utils.getChromiumBranchingPoint()
       .then(downloadChromiumRevision)
       .then(path => unzipArchive(path, binPath))
       .catch(err => console.error('An error occurred while trying to setup Chromium. Resolve all issues and restart the process', err));

--- a/download-chrome.js
+++ b/download-chrome.js
@@ -91,7 +91,7 @@ function unzipArchive (archivePath, outputFolder) {
 }
 
 module.exports = (function () {
-  const { execPath, binPath, versionNumber } = utils.getBinaryPath();
+  const { execPath, binPath } = utils.getBinaryPath();
   const exists = fs.existsSync(execPath);
 
   if (exists) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-chromium",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "One place to hold all the logic to download and run ember tests in chromium",
   "main": "index.js",
   "bin": {

--- a/utils.js
+++ b/utils.js
@@ -4,7 +4,8 @@ const path = require('path');
 const got = require('got');
 const childProcess = require('child_process');
 
-const REQUESTED_VERSION = process.env.CHROMIUM_VERSION || '86.0.0';
+// HEADS UP: min supported by chromiumdash is 94
+const REQUESTED_VERSION = process.env.CHROMIUM_VERSION || '121.0.6156.3';
 const REQUESTED_CHANNEL = process.env.CHROMIUM_CHANNEL || 'dev';
 const versionsWithUnknownBranchingPoint = [];
 
@@ -27,35 +28,57 @@ function getCurrentOs () {
   throw new Error('Unsupported platform');
 }
 
-function getExactChromeVersionNumber () {
+function getReleaseWithBranchingPoint(channel, platform, version) {
   return new Promise((resolve, reject) => {
-    const url = 'https://omahaproxy.appspot.com/history.json?channel=' + REQUESTED_CHANNEL + '&os=' + getCurrentOs();
-    const packageMajorVersion = REQUESTED_VERSION.split('.')[0];
+    const majorVersion = getMajorVersion(version);
+    if (!majorVersion) {
+      reject('Unable to determine request major chromium version');
+    }
+
+    const url = `https://chromiumdash.appspot.com/fetch_releases?channel${channel}&platform=${platform}\&num\=10\&offset\=0\&milestone\=${majorVersion}`;
 
     got(url)
       .then(response => {
         let versions = JSON.parse(response.body);
 
         for (let version of versions) {
-          let versionNumber = version.version;
-          let buildMajorVersion = versionNumber.split('.')[0];
+          if (version.milestone === majorVersion &&
+            version.version.indexOf(majorVersion + '.') === 0 &&
+            version.chromium_main_branch_position) {
+            let branchingPoint = parseInt(version.chromium_main_branch_position, 10);
 
-          if (buildMajorVersion !== packageMajorVersion) {
-            continue;
+            if (Number.isInteger(branchingPoint)) {
+              resolve({
+                version: version.version,
+                branchingPoint
+              });
+            }
           }
-
-          if (versionsWithUnknownBranchingPoint.includes(versionNumber)) {
-            continue;
-          }
-
-          return resolve(versionNumber);
         }
-      }
-      )
+
+        reject(`No branching point found for ${channel}, ${platform}, ${majorVersion} (${version})`)
+      })
       .catch(err => {
         console.log('An error occured while trying to retrieve latest revision number', err);
         reject(err);
       });
+  });
+}
+
+function getMajorVersion(versionString) {
+  const majorVersion = parseInt(versionString.split('.')[0], 10);
+  if (Number.isInteger(majorVersion)) {
+    return majorVersion;
+  }
+
+  return null;
+}
+
+function getExactChromeVersionNumber() {
+  return getReleaseWithBranchingPoint(REQUESTED_CHANNEL, getCurrentOs(), REQUESTED_VERSION).then(releaseDetails => {
+    if (releaseDetails) {
+      return releaseDetails.version;
+    }
   });
 }
 
@@ -97,30 +120,9 @@ function getBinaryPath () {
   return {binPath, execPath, versionNumber};
 }
 
-function getChromiumBranchingPoint (versionNumber) {
-  return new Promise((resolve, reject) => {
-    const url = 'https://omahaproxy.appspot.com/deps.json?version=' + versionNumber;
-
-    got(url)
-      .then(response => {
-        let versionDetails = JSON.parse(response.body);
-        let branchingPoint = parseInt(versionDetails.chromium_base_position);
-
-        if (!Number.isInteger(branchingPoint)) {
-          console.log('Could not find branching point for Chrome ' + versionNumber + '. This can happen when the new Chrome version is just branched off. Let\'s try to find the branching point for one version earlier.');
-          versionsWithUnknownBranchingPoint.push(versionNumber);
-
-          resolve(getExactChromeVersionNumber().then(getChromiumBranchingPoint));
-        }
-
-        console.log('Found that Chrome ' + versionNumber + ' was branched off Chromium at point ' + branchingPoint);
-
-        resolve(branchingPoint);
-      })
-      .catch(err => {
-        console.log('Could not get build details for version ' + versionNumber);
-        reject(err);
-      });
+function getChromiumBranchingPoint() {
+  return getReleaseWithBranchingPoint(REQUESTED_CHANNEL, getCurrentOs(), REQUESTED_VERSION).then(releaseDetails => {
+    return releaseDetails.branchingPoint;
   });
 }
 


### PR DESCRIPTION
This is a minimal change to port over to chromiumdash without incurring major redesigns to the repo.

A full refactor of this repo, while sorely needed, would be ill-advised at this point. Other solutions such as docker containers, playwright, or puppeteer should be used over this legacy library.