### PR TITLE
Add support for newer versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-chromium",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "One place to hold all the logic to download and run ember tests in chromium",
   "main": "index.js",
   "bin": {

--- a/utils.js
+++ b/utils.js
@@ -105,7 +105,6 @@ function getBinaryPath () {
 
   const platform = getCurrentOs();
 
-
   let buffer;
   let binPath;
 
@@ -123,9 +122,7 @@ function getBinaryPath () {
     binPath = path.join(globalPath, 'ember-chromium', versionNumber);
   }
 
-
   let execPath;
-
   const folderName = getOsChromiumFolderName();
 
   switch(platform) {

--- a/utils.js
+++ b/utils.js
@@ -104,12 +104,26 @@ function getBinaryPath () {
   }
 
   const platform = getCurrentOs();
-  const searchCommand = platform === 'win' ? 'gcm' : 'which'
-  const buffer = childProcess.execSync(`${searchCommand} npm`);
-  const result = String.fromCharCode.apply(null, buffer);
-  let npmGlobalPath = result.replace(/\n$/, '').split('/');
-  const globalPath = npmGlobalPath.slice(0, npmGlobalPath.length - 1).join('/');
-  let binPath = path.join(globalPath, 'ember-chromium', versionNumber);
+
+
+  let buffer;
+  let binPath;
+
+  // This is a lazy fix for newer node versions on unix.  Was having problems testing on windows, and most of our devs are not using windows
+  if (platform === 'win') {
+    buffer = childProcess.execSync('npm bin -g');
+    const result = String.fromCharCode.apply(null, buffer);
+    const globalPath = result.replace(/\n$/, '');
+    binPath = path.join(globalPath, 'ember-chromium', versionNumber);
+  } else {
+    buffer = childProcess.execSync('which npm');
+    const result = String.fromCharCode.apply(null, buffer);
+    const npmGlobalPath = result.replace(/\n$/, '').split('/');
+    const globalPath = npmGlobalPath.slice(0, npmGlobalPath.length - 1).join('/');
+    binPath = path.join(globalPath, 'ember-chromium', versionNumber);
+  }
+
+
   let execPath;
 
   const folderName = getOsChromiumFolderName();


### PR DESCRIPTION
`npm bin` is no longer a supported command.   I validated this works on my mac using node 14 and node 18. I don't have a good way to test with windows, so I'll want a way to verify that before merging this change and releasing. 

